### PR TITLE
Feature/types

### DIFF
--- a/postman/tests.types.json
+++ b/postman/tests.types.json
@@ -1,0 +1,1031 @@
+{
+  "info": {
+    "_postman_id": "00da7379-4041-478a-a18e-d689090b0d8f",
+    "name": "Types",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "32481832"
+  },
+  "item": [
+    {
+      "name": "/api/types",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "localhost:3000/api/types",
+          "host": ["localhost"],
+          "port": "3000",
+          "path": ["api", "types"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "/api/types pagination",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "localhost:3000/api/types?page=2&pageSize=5",
+          "host": ["localhost"],
+          "port": "3000",
+          "path": ["api", "types"],
+          "query": [
+            {
+              "key": "page",
+              "value": "2"
+            },
+            {
+              "key": "pageSize",
+              "value": "5"
+            }
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "/api/types/{id}",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "localhost:3000/api/types/2",
+          "host": ["localhost"],
+          "port": "3000",
+          "path": ["api", "types", "2"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "/api/types/{id} error 400",
+      "request": {
+        "auth": {
+          "type": "noauth"
+        },
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "localhost:3000/api/types/id",
+          "host": ["localhost"],
+          "port": "3000",
+          "path": ["api", "types", "id"]
+        }
+      },
+      "response": [
+        {
+          "name": "localhost:3000/api/types/id",
+          "originalRequest": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "localhost:3000/api/types/id",
+              "host": ["localhost"],
+              "port": "3000",
+              "path": ["api", "types", "id"]
+            }
+          },
+          "status": "Bad Request",
+          "code": 400,
+          "_postman_previewlanguage": "json",
+          "header": [
+            {
+              "key": "X-Powered-By",
+              "value": "Express"
+            },
+            {
+              "key": "Content-Type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "key": "Content-Length",
+              "value": "36"
+            },
+            {
+              "key": "ETag",
+              "value": "W/\"24-qUtCTx1e8GUFQbEY/VRm0sdr+1g\""
+            },
+            {
+              "key": "Date",
+              "value": "Fri, 21 Mar 2025 08:57:24 GMT"
+            },
+            {
+              "key": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "key": "Keep-Alive",
+              "value": "timeout=5"
+            }
+          ],
+          "cookie": [],
+          "body": "{\n    \"error\": \"Type ID must be a number\"\n}"
+        }
+      ]
+    },
+    {
+      "name": "/api/types/{id} error 404 type not found",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "localhost:3000/api/types/5",
+          "host": ["localhost"],
+          "port": "3000",
+          "path": ["api", "types", "5"]
+        }
+      },
+      "response": [
+        {
+          "name": "/api/types/{id} Copy",
+          "originalRequest": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "localhost:3000/api/types/5",
+              "host": ["localhost"],
+              "port": "3000",
+              "path": ["api", "types", "5"]
+            }
+          },
+          "status": "Not Found",
+          "code": 404,
+          "_postman_previewlanguage": "json",
+          "header": [
+            {
+              "key": "X-Powered-By",
+              "value": "Express"
+            },
+            {
+              "key": "Content-Type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "key": "Content-Length",
+              "value": "26"
+            },
+            {
+              "key": "ETag",
+              "value": "W/\"1a-/aoQUvSIFUcQEz43jdp7N5Nklmo\""
+            },
+            {
+              "key": "Date",
+              "value": "Fri, 21 Mar 2025 08:55:21 GMT"
+            },
+            {
+              "key": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "key": "Keep-Alive",
+              "value": "timeout=5"
+            }
+          ],
+          "cookie": [],
+          "body": "{\n    \"error\": \"Type not found\"\n}"
+        }
+      ]
+    },
+    {
+      "name": "/api/types",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\"name\":\"Concert\"}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "localhost:3000/api/types",
+          "host": ["localhost"],
+          "port": "3000",
+          "path": ["api", "types"],
+          "query": [
+            {
+              "key": "",
+              "value": null,
+              "disabled": true
+            }
+          ]
+        }
+      },
+      "response": [
+        {
+          "name": "/api/types",
+          "originalRequest": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"name\":\"Concert\"}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "localhost:3000/api/types",
+              "host": ["localhost"],
+              "port": "3000",
+              "path": ["api", "types"],
+              "query": [
+                {
+                  "key": "",
+                  "value": null,
+                  "disabled": true
+                }
+              ]
+            }
+          },
+          "status": "Created",
+          "code": 201,
+          "_postman_previewlanguage": "json",
+          "header": [
+            {
+              "key": "X-Powered-By",
+              "value": "Express"
+            },
+            {
+              "key": "Content-Type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "key": "Content-Length",
+              "value": "26"
+            },
+            {
+              "key": "ETag",
+              "value": "W/\"1a-TQFFVBTGBjnPa68SAaMDMifN4N0\""
+            },
+            {
+              "key": "Date",
+              "value": "Fri, 21 Mar 2025 09:15:30 GMT"
+            },
+            {
+              "key": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "key": "Keep-Alive",
+              "value": "timeout=5"
+            }
+          ],
+          "cookie": [],
+          "body": "{\n    \"id\": 17,\n    \"name\": \"Concert\"\n}"
+        }
+      ]
+    },
+    {
+      "name": "/api/types error 400",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\"name\":2}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "localhost:3000/api/types",
+          "host": ["localhost"],
+          "port": "3000",
+          "path": ["api", "types"],
+          "query": [
+            {
+              "key": "",
+              "value": null,
+              "disabled": true
+            }
+          ]
+        }
+      },
+      "response": [
+        {
+          "name": "/api/types error 400",
+          "originalRequest": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"name\":2}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "localhost:3000/api/types",
+              "host": ["localhost"],
+              "port": "3000",
+              "path": ["api", "types"],
+              "query": [
+                {
+                  "key": "",
+                  "value": null,
+                  "disabled": true
+                }
+              ]
+            }
+          },
+          "status": "Bad Request",
+          "code": 400,
+          "_postman_previewlanguage": "json",
+          "header": [
+            {
+              "key": "X-Powered-By",
+              "value": "Express"
+            },
+            {
+              "key": "Content-Type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "key": "Content-Length",
+              "value": "37"
+            },
+            {
+              "key": "ETag",
+              "value": "W/\"25-sEENU6PPJDW3x+oGKp75XLdZ2J8\""
+            },
+            {
+              "key": "Date",
+              "value": "Fri, 21 Mar 2025 09:37:43 GMT"
+            },
+            {
+              "key": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "key": "Keep-Alive",
+              "value": "timeout=5"
+            }
+          ],
+          "cookie": [],
+          "body": "{\n    \"error\": \"\\\"name\\\" must be a string\"\n}"
+        }
+      ]
+    },
+    {
+      "name": "/api/types error 409 type already exists",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\"name\":\"Concert\"}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "localhost:3000/api/types",
+          "host": ["localhost"],
+          "port": "3000",
+          "path": ["api", "types"]
+        }
+      },
+      "response": [
+        {
+          "name": "error 409",
+          "originalRequest": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"name\":\"Concert\"}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "localhost:3000/api/types",
+              "host": ["localhost"],
+              "port": "3000",
+              "path": ["api", "types"]
+            }
+          },
+          "status": "Conflict",
+          "code": 409,
+          "_postman_previewlanguage": "json",
+          "header": [
+            {
+              "key": "X-Powered-By",
+              "value": "Express"
+            },
+            {
+              "key": "Content-Type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "key": "Content-Length",
+              "value": "31"
+            },
+            {
+              "key": "ETag",
+              "value": "W/\"1f-5nZF4v4+enqGu1YQrre4lkl9EL4\""
+            },
+            {
+              "key": "Date",
+              "value": "Fri, 21 Mar 2025 09:16:22 GMT"
+            },
+            {
+              "key": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "key": "Keep-Alive",
+              "value": "timeout=5"
+            }
+          ],
+          "cookie": [],
+          "body": "{\n    \"error\": \"Type already exists\"\n}"
+        }
+      ]
+    },
+    {
+      "name": "/api/types/{id}",
+      "request": {
+        "method": "PUT",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\"name\":\"Seminar\"}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "localhost:3000/api/types/2",
+          "host": ["localhost"],
+          "port": "3000",
+          "path": ["api", "types", "2"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "/api/types/{id} error 400",
+      "request": {
+        "method": "PUT",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\"name\":\"Seminar\"}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "localhost:3000/api/types/id",
+          "host": ["localhost"],
+          "port": "3000",
+          "path": ["api", "types", "id"]
+        }
+      },
+      "response": [
+        {
+          "name": "/api/types/{id} Copy",
+          "originalRequest": {
+            "method": "PUT",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"name\":\"Seminar\"}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "localhost:3000/api/types/id",
+              "host": ["localhost"],
+              "port": "3000",
+              "path": ["api", "types", "id"]
+            }
+          },
+          "status": "Bad Request",
+          "code": 400,
+          "_postman_previewlanguage": "json",
+          "header": [
+            {
+              "key": "X-Powered-By",
+              "value": "Express"
+            },
+            {
+              "key": "Content-Type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "key": "Content-Length",
+              "value": "36"
+            },
+            {
+              "key": "ETag",
+              "value": "W/\"24-qUtCTx1e8GUFQbEY/VRm0sdr+1g\""
+            },
+            {
+              "key": "Date",
+              "value": "Fri, 21 Mar 2025 09:28:56 GMT"
+            },
+            {
+              "key": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "key": "Keep-Alive",
+              "value": "timeout=5"
+            }
+          ],
+          "cookie": [],
+          "body": "{\n    \"error\": \"Type ID must be a number\"\n}"
+        }
+      ]
+    },
+    {
+      "name": "/api/types/{id} error 400 name required",
+      "request": {
+        "method": "PUT",
+        "header": [],
+        "url": {
+          "raw": "localhost:3000/api/types/2",
+          "host": ["localhost"],
+          "port": "3000",
+          "path": ["api", "types", "2"]
+        }
+      },
+      "response": [
+        {
+          "name": "/api/types/{id} error 400 Copy",
+          "originalRequest": {
+            "method": "PUT",
+            "header": [],
+            "url": {
+              "raw": "localhost:3000/api/types/2",
+              "host": ["localhost"],
+              "port": "3000",
+              "path": ["api", "types", "2"]
+            }
+          },
+          "status": "Bad Request",
+          "code": 400,
+          "_postman_previewlanguage": "json",
+          "header": [
+            {
+              "key": "X-Powered-By",
+              "value": "Express"
+            },
+            {
+              "key": "Content-Type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "key": "Content-Length",
+              "value": "32"
+            },
+            {
+              "key": "ETag",
+              "value": "W/\"20-Gf1XqWtgTj7hWCFJzfQJMKr1rAg\""
+            },
+            {
+              "key": "Date",
+              "value": "Fri, 21 Mar 2025 09:29:22 GMT"
+            },
+            {
+              "key": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "key": "Keep-Alive",
+              "value": "timeout=5"
+            }
+          ],
+          "cookie": [],
+          "body": "{\n    \"error\": \"\\\"name\\\" is required\"\n}"
+        }
+      ]
+    },
+    {
+      "name": "/api/types/{id} error 404 type not existing",
+      "request": {
+        "method": "PUT",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\"name\":\"modified\"}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "localhost:3000/api/types/42",
+          "host": ["localhost"],
+          "port": "3000",
+          "path": ["api", "types", "42"]
+        }
+      },
+      "response": [
+        {
+          "name": "/api/types/{id} error 404 type not existing Copy",
+          "originalRequest": {
+            "method": "PUT",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"name\":\"modified\"}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "localhost:3000/api/types/42",
+              "host": ["localhost"],
+              "port": "3000",
+              "path": ["api", "types", "42"]
+            }
+          },
+          "status": "Not Found",
+          "code": 404,
+          "_postman_previewlanguage": "json",
+          "header": [
+            {
+              "key": "X-Powered-By",
+              "value": "Express"
+            },
+            {
+              "key": "Content-Type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "key": "Content-Length",
+              "value": "26"
+            },
+            {
+              "key": "ETag",
+              "value": "W/\"1a-/aoQUvSIFUcQEz43jdp7N5Nklmo\""
+            },
+            {
+              "key": "Date",
+              "value": "Fri, 21 Mar 2025 09:34:15 GMT"
+            },
+            {
+              "key": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "key": "Keep-Alive",
+              "value": "timeout=5"
+            }
+          ],
+          "cookie": [],
+          "body": "{\n    \"error\": \"Type not found\"\n}"
+        }
+      ]
+    },
+    {
+      "name": "/api/types/{id} error 409 type already exists",
+      "request": {
+        "method": "PUT",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\"name\":\"Concert\"}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "localhost:3000/api/types/2",
+          "host": ["localhost"],
+          "port": "3000",
+          "path": ["api", "types", "2"]
+        }
+      },
+      "response": [
+        {
+          "name": "/api/types/{id} error 409 type already exists",
+          "originalRequest": {
+            "method": "PUT",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"name\":\"Concert\"}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "localhost:3000/api/types/2",
+              "host": ["localhost"],
+              "port": "3000",
+              "path": ["api", "types", "2"]
+            }
+          },
+          "status": "Conflict",
+          "code": 409,
+          "_postman_previewlanguage": "json",
+          "header": [
+            {
+              "key": "X-Powered-By",
+              "value": "Express"
+            },
+            {
+              "key": "Content-Type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "key": "Content-Length",
+              "value": "31"
+            },
+            {
+              "key": "ETag",
+              "value": "W/\"1f-5nZF4v4+enqGu1YQrre4lkl9EL4\""
+            },
+            {
+              "key": "Date",
+              "value": "Fri, 21 Mar 2025 09:28:14 GMT"
+            },
+            {
+              "key": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "key": "Keep-Alive",
+              "value": "timeout=5"
+            }
+          ],
+          "cookie": [],
+          "body": "{\n    \"error\": \"Type already exists\"\n}"
+        }
+      ]
+    },
+    {
+      "name": "/api/types/{id}",
+      "request": {
+        "method": "DELETE",
+        "header": [],
+        "url": {
+          "raw": "localhost:3000/api/types/15",
+          "host": ["localhost"],
+          "port": "3000",
+          "path": ["api", "types", "15"]
+        }
+      },
+      "response": [
+        {
+          "name": "/api/types/{id}",
+          "originalRequest": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "localhost:3000/api/types/15",
+              "host": ["localhost"],
+              "port": "3000",
+              "path": ["api", "types", "15"]
+            }
+          },
+          "status": "No Content",
+          "code": 204,
+          "_postman_previewlanguage": "plain",
+          "header": [
+            {
+              "key": "X-Powered-By",
+              "value": "Express"
+            },
+            {
+              "key": "Date",
+              "value": "Fri, 21 Mar 2025 09:35:22 GMT"
+            },
+            {
+              "key": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "key": "Keep-Alive",
+              "value": "timeout=5"
+            }
+          ],
+          "cookie": [],
+          "body": null
+        }
+      ]
+    },
+    {
+      "name": "/api/types/{id} error 400",
+      "request": {
+        "method": "DELETE",
+        "header": [],
+        "url": {
+          "raw": "localhost:3000/api/types/id",
+          "host": ["localhost"],
+          "port": "3000",
+          "path": ["api", "types", "id"]
+        }
+      },
+      "response": [
+        {
+          "name": "/api/types/{id} error 400",
+          "originalRequest": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "localhost:3000/api/types/id",
+              "host": ["localhost"],
+              "port": "3000",
+              "path": ["api", "types", "id"]
+            }
+          },
+          "status": "Bad Request",
+          "code": 400,
+          "_postman_previewlanguage": "json",
+          "header": [
+            {
+              "key": "X-Powered-By",
+              "value": "Express"
+            },
+            {
+              "key": "Content-Type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "key": "Content-Length",
+              "value": "36"
+            },
+            {
+              "key": "ETag",
+              "value": "W/\"24-qUtCTx1e8GUFQbEY/VRm0sdr+1g\""
+            },
+            {
+              "key": "Date",
+              "value": "Fri, 21 Mar 2025 09:36:03 GMT"
+            },
+            {
+              "key": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "key": "Keep-Alive",
+              "value": "timeout=5"
+            }
+          ],
+          "cookie": [],
+          "body": "{\n    \"error\": \"Type ID must be a number\"\n}"
+        }
+      ]
+    },
+    {
+      "name": "/api/types/{id} error 404 type not existing",
+      "request": {
+        "method": "DELETE",
+        "header": [],
+        "url": {
+          "raw": "localhost:3000/api/types/42",
+          "host": ["localhost"],
+          "port": "3000",
+          "path": ["api", "types", "42"]
+        }
+      },
+      "response": [
+        {
+          "name": "New Request",
+          "originalRequest": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "localhost:3000/api/types/42",
+              "host": ["localhost"],
+              "port": "3000",
+              "path": ["api", "types", "42"]
+            }
+          },
+          "status": "Not Found",
+          "code": 404,
+          "_postman_previewlanguage": "json",
+          "header": [
+            {
+              "key": "X-Powered-By",
+              "value": "Express"
+            },
+            {
+              "key": "Content-Type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "key": "Content-Length",
+              "value": "26"
+            },
+            {
+              "key": "ETag",
+              "value": "W/\"1a-/aoQUvSIFUcQEz43jdp7N5Nklmo\""
+            },
+            {
+              "key": "Date",
+              "value": "Fri, 21 Mar 2025 09:33:26 GMT"
+            },
+            {
+              "key": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "key": "Keep-Alive",
+              "value": "timeout=5"
+            }
+          ],
+          "cookie": [],
+          "body": "{\n    \"error\": \"Type not found\"\n}"
+        }
+      ]
+    },
+    {
+      "name": "/api/types/{id} error 409 used by events",
+      "request": {
+        "method": "DELETE",
+        "header": [],
+        "url": {
+          "raw": "localhost:3000/api/types/2",
+          "host": ["localhost"],
+          "port": "3000",
+          "path": ["api", "types", "2"]
+        }
+      },
+      "response": [
+        {
+          "name": "/api/types/{id} error 409 used by events",
+          "originalRequest": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "localhost:3000/api/types/2",
+              "host": ["localhost"],
+              "port": "3000",
+              "path": ["api", "types", "2"]
+            }
+          },
+          "status": "Conflict",
+          "code": 409,
+          "_postman_previewlanguage": "json",
+          "header": [
+            {
+              "key": "X-Powered-By",
+              "value": "Express"
+            },
+            {
+              "key": "Content-Type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "key": "Content-Length",
+              "value": "69"
+            },
+            {
+              "key": "ETag",
+              "value": "W/\"45-8zKD4w+DOOk6bfAXCHxC1/TgHpY\""
+            },
+            {
+              "key": "Date",
+              "value": "Fri, 21 Mar 2025 09:36:43 GMT"
+            },
+            {
+              "key": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "key": "Keep-Alive",
+              "value": "timeout=5"
+            }
+          ],
+          "cookie": [],
+          "body": "{\n    \"error\": \"Cannot delete type because it is used by existing events.\"\n}"
+        }
+      ]
+    }
+  ]
+}

--- a/src/controllers/types.controller.ts
+++ b/src/controllers/types.controller.ts
@@ -1,0 +1,95 @@
+import { Request, Response } from "express";
+import { TypeService } from "../services/types.service";
+import { typeIdSchema, typeSchema } from "../schemas/types.schema";
+
+export class TypeController {
+  static async getTypes(req: Request, res: Response) {
+    try {
+      const types = await TypeService.getTypes();
+      res.status(200).send(types);
+    } catch (error) {
+      res
+        .status(500)
+        .send({ error: "Internal server error", message: error.message });
+    }
+  }
+
+  static async getTypeById(req: Request, res: Response) {
+    try {
+      const id = parseInt(req.params.id);
+      //validate
+      const { error } = typeIdSchema.validate({ id });
+      if (error) {
+        res.status(400).json({ error: error.details[0].message });
+        return;
+      }
+      const type = await TypeService.getTypeById(id);
+      if (!type) {
+        res.status(404).json({ error: "Type not found" });
+        return;
+      }
+      res.status(200).send(type);
+    } catch (error) {
+      res
+        .status(500)
+        .send({ error: "Internal server error", message: error.message });
+    }
+  }
+
+  static async createType(req: Request, res: Response) {
+    try {
+      const { name } = req.body;
+      const { error } = typeSchema.validate({ name });
+      if (error) {
+        res.status(400).json({ error: error.details[0].message });
+        return;
+      }
+      const newType = await TypeService.createType(name);
+      res.status(201).send(newType);
+    } catch (error) {
+      res
+        .status(500)
+        .send({ error: "Internal server error", message: error.message });
+    }
+  }
+
+  static async updateType(req: Request, res: Response) {
+    try {
+      const id = parseInt(req.params.id);
+      const { error: errorId } = typeIdSchema.validate({ id });
+      if (errorId) {
+        res.status(400).json({ error: errorId.details[0].message });
+        return;
+      }
+      const { name } = req.body;
+      const { error } = typeSchema.validate({ name });
+      if (error) {
+        res.status(400).json({ error: error.details[0].message });
+        return;
+      }
+      const updatedType = await TypeService.updateType(id, { name });
+      res.status(200).send(updatedType);
+    } catch (error) {
+      res
+        .status(500)
+        .send({ error: "Internal server error", message: error.message });
+    }
+  }
+
+  static async deleteType(req: Request, res: Response) {
+    try {
+      const id = parseInt(req.params.id);
+      const { error } = typeIdSchema.validate({ id });
+      if (error) {
+        res.status(400).json({ error: error.details[0].message });
+        return;
+      }
+      await TypeService.deleteType(id);
+      res.status(204).send();
+    } catch (error) {
+      res
+        .status(500)
+        .send({ error: "Internal server error", message: error.message });
+    }
+  }
+}

--- a/src/controllers/types.controller.ts
+++ b/src/controllers/types.controller.ts
@@ -44,6 +44,12 @@ export class TypeController {
         res.status(400).json({ error: error.details[0].message });
         return;
       }
+
+      if (await TypeService.typeExists(name)) {
+        res.status(409).json({ error: "Type already exists" });
+        return;
+      }
+
       const newType = await TypeService.createType(name);
       res.status(201).send(newType);
     } catch (error) {
@@ -67,6 +73,12 @@ export class TypeController {
         res.status(400).json({ error: error.details[0].message });
         return;
       }
+
+      if (await TypeService.typeExists(name)) {
+        res.status(409).json({ error: "Type already exists" });
+        return;
+      }
+
       const updatedType = await TypeService.updateType(id, { name });
       res.status(200).send(updatedType);
     } catch (error) {
@@ -84,6 +96,16 @@ export class TypeController {
         res.status(400).json({ error: error.details[0].message });
         return;
       }
+
+      if (await TypeService.isUsedByEvents(id)) {
+        res
+          .status(409)
+          .json({
+            error: "Cannot delete type because it is used by existing events.",
+          });
+        return;
+      }
+
       await TypeService.deleteType(id);
       res.status(204).send();
     } catch (error) {

--- a/src/controllers/types.controller.ts
+++ b/src/controllers/types.controller.ts
@@ -87,6 +87,12 @@ export class TypeController {
         return;
       }
 
+      const type = await TypeService.getTypeById(id);
+      if (!type) {
+        res.status(404).json({ error: "Type not found" });
+        return;
+      }
+
       if (await TypeService.typeExists(name)) {
         res.status(409).json({ error: "Type already exists" });
         return;
@@ -107,6 +113,12 @@ export class TypeController {
       const { error } = typeIdSchema.validate({ id });
       if (error) {
         res.status(400).json({ error: error.details[0].message });
+        return;
+      }
+
+      const type = await TypeService.getTypeById(id);
+      if (!type) {
+        res.status(404).json({ error: "Type not found" });
         return;
       }
 

--- a/src/entities/types.entity.ts
+++ b/src/entities/types.entity.ts
@@ -1,0 +1,10 @@
+export class Type {
+  constructor(
+    public id: number,
+    public name: string,
+  ) {}
+
+  static fromPrisma(prismaType: any): Type {
+    return new Type(prismaType.id, prismaType.name);
+  }
+}

--- a/src/repositories/events.repository.ts
+++ b/src/repositories/events.repository.ts
@@ -82,6 +82,7 @@ export class EventRepository {
       page: pageNumber,
       pageSize: pageSizeNumber,
     };
+  }
 
   static async createEvent(eventData: {
     name: string;

--- a/src/repositories/types.repository.ts
+++ b/src/repositories/types.repository.ts
@@ -48,4 +48,22 @@ export class TypeRepository {
       },
     });
   }
+
+  static async typeExists(name: string) {
+    const type = await prisma.type.findFirst({
+      where: {
+        name,
+      },
+    });
+    return !!type;
+  }
+
+  static async isUsedByEvents(id: number) {
+    const events = await prisma.event.findMany({
+      where: {
+        typeId: id,
+      },
+    });
+    return events.length > 0;
+  }
 }

--- a/src/repositories/types.repository.ts
+++ b/src/repositories/types.repository.ts
@@ -1,0 +1,45 @@
+import { Prisma } from "@prisma/client";
+import { prisma } from "../prismaClient";
+
+export class TypeRepository {
+  static async getTypes() {
+    //order by id
+    return prisma.type.findMany({
+      orderBy: {
+        id: Prisma.SortOrder.asc,
+      },
+    });
+  }
+  static async getTypeById(id: number) {
+    return prisma.type.findUnique({
+      where: {
+        id,
+      },
+    });
+  }
+
+  static async createType(name: string) {
+    return prisma.type.create({
+      data: {
+        name,
+      },
+    });
+  }
+
+  static async updateType(id: number, data: { name: string }) {
+    return prisma.type.update({
+      where: {
+        id,
+      },
+      data,
+    });
+  }
+
+  static async deleteType(id: number) {
+    return prisma.type.delete({
+      where: {
+        id,
+      },
+    });
+  }
+}

--- a/src/repositories/types.repository.ts
+++ b/src/repositories/types.repository.ts
@@ -1,38 +1,44 @@
 import { Prisma } from "@prisma/client";
 import { prisma } from "../prismaClient";
+import { Type } from "../entities/types.entity";
 
 export class TypeRepository {
   static async getTypes() {
     //order by id
-    return prisma.type.findMany({
+    const types = await prisma.type.findMany({
       orderBy: {
         id: Prisma.SortOrder.asc,
       },
     });
+    return types.map((type) => Type.fromPrisma(type));
   }
+
   static async getTypeById(id: number) {
-    return prisma.type.findUnique({
+    const type = await prisma.type.findUnique({
       where: {
         id,
       },
     });
+    return Type.fromPrisma(type);
   }
 
   static async createType(name: string) {
-    return prisma.type.create({
+    const newType = await prisma.type.create({
       data: {
         name,
       },
     });
+    return Type.fromPrisma(newType);
   }
 
   static async updateType(id: number, data: { name: string }) {
-    return prisma.type.update({
+    const type = await prisma.type.update({
       where: {
         id,
       },
       data,
     });
+    return Type.fromPrisma(type);
   }
 
   static async deleteType(id: number) {

--- a/src/repositories/types.repository.ts
+++ b/src/repositories/types.repository.ts
@@ -3,14 +3,27 @@ import { prisma } from "../prismaClient";
 import { Type } from "../entities/types.entity";
 
 export class TypeRepository {
-  static async getTypes() {
-    //order by id
+  static async getTypes(filters: any) {
+    const { page, pageSize } = filters;
+    const pageNumber = Math.max(1, parseInt(page));
+    const pageSizeNumber = Math.max(1, parseInt(pageSize));
+    const limit = pageSizeNumber;
+    const offset = (pageNumber - 1) * pageSizeNumber;
+
     const types = await prisma.type.findMany({
+      take: limit,
+      skip: offset,
       orderBy: {
         id: Prisma.SortOrder.asc,
       },
     });
-    return types.map((type) => Type.fromPrisma(type));
+    const total = await prisma.type.count();
+    return {
+      types: types.map((type) => Type.fromPrisma(type)),
+      total,
+      page: pageNumber,
+      pageSize: pageSizeNumber,
+    };
   }
 
   static async getTypeById(id: number) {

--- a/src/repositories/types.repository.ts
+++ b/src/repositories/types.repository.ts
@@ -32,6 +32,9 @@ export class TypeRepository {
         id,
       },
     });
+    if (!type) {
+      return null;
+    }
     return Type.fromPrisma(type);
   }
 

--- a/src/routes/events.route.ts
+++ b/src/routes/events.route.ts
@@ -1,5 +1,4 @@
-import { Router, Request, Response } from "express";
-import { prisma } from "../prismaClient";
+import { Router } from "express";
 import { EventController } from "../controllers/events.controller";
 
 const router = Router();
@@ -10,12 +9,12 @@ const router = Router();
  *   get:
  *     tags:
  *       - Events
- *     description: Get the list of events
+ *     summary: Get the list of events
  *     parameters:
  *       - name: status
  *         in: query
  *         required: false
- *         description: Filter events by status (moderated)
+ *         description: Filter events by status (moderated/unmoderated)
  *         schema:
  *           type: string
  *       - name: type

--- a/src/routes/types.route.ts
+++ b/src/routes/types.route.ts
@@ -9,6 +9,19 @@ const router = Router();
  *     tags:
  *       - Types
  *     summary: Get a list of all event types
+ *     parameters:
+ *        - in: query
+ *          name: page
+ *          schema:
+ *            type: integer
+ *            default: 1
+ *          description: Page number
+ *        - in: query
+ *          name: pageSize
+ *          schema:
+ *            type: integer
+ *            default: 10
+ *          description: Number of items per page
  *     responses:
  *       200:
  *         description: Successfully retrieved the list of types

--- a/src/routes/types.route.ts
+++ b/src/routes/types.route.ts
@@ -98,6 +98,8 @@ router.get("/types/:id", TypeController.getTypeById);
  *         description: Type created successfully
  *       400:
  *         description: Missing required field
+ *       409:
+ *         description: Type already exists
  */
 router.post("/types", TypeController.createType);
 
@@ -132,6 +134,8 @@ router.post("/types", TypeController.createType);
  *         description: Invalid ID or missing required field
  *       404:
  *         description: Type not found
+ *       409:
+ *         description: Type already exists
  */
 router.put("/types/:id", TypeController.updateType);
 
@@ -156,6 +160,8 @@ router.put("/types/:id", TypeController.updateType);
  *         description: Invalid ID format
  *       404:
  *         description: Type not found
+ *       409:
+ *         description: Type already exists
  */
 router.delete("/types/:id", TypeController.deleteType);
 

--- a/src/routes/types.route.ts
+++ b/src/routes/types.route.ts
@@ -1,6 +1,67 @@
-import { Router, Request, Response } from "express";
-import { prisma } from "../prismaClient";
+import { Router } from "express";
+import { TypeController } from "../controllers/types.controller";
 const router = Router();
+
+/**
+ * @swagger
+ * /api/types:
+ *   get:
+ *     tags:
+ *       - Types
+ *     summary: Get a list of all event types
+ *     responses:
+ *       200:
+ *         description: Successfully retrieved the list of types
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   id:
+ *                     type: integer
+ *                     example: 1
+ *                   name:
+ *                     type: string
+ *                     example: "Flea market"
+ */
+router.get("/types", TypeController.getTypes);
+
+/**
+ * @swagger
+ * /api/types/{id}:
+ *   get:
+ *     tags:
+ *       - Types
+ *     summary: Retrieve a specific event type by ID
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *         description: The ID of the type to retrieve
+ *     responses:
+ *       200:
+ *         description: Successfully retrieved the type
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 id:
+ *                   type: integer
+ *                   example: 1
+ *                 name:
+ *                   type: string
+ *                   example: "Conference"
+ *       400:
+ *         description: Invalid ID format
+ *       404:
+ *         description: Type not found
+ */
+router.get("/types/:id", TypeController.getTypeById);
 
 /**
  * @swagger
@@ -25,26 +86,64 @@ const router = Router();
  *       400:
  *         description: Missing required field
  */
-router.post("/types", async (req: Request, res: Response) => {
-  try {
-    const { name } = req.body;
+router.post("/types", TypeController.createType);
 
-    if (!name) {
-      res.status(400).json({ error: "Name is required" });
-      return;
-    }
+/**
+ * @swagger
+ * /api/types/{id}:
+ *   put:
+ *     tags:
+ *       - Types
+ *     summary: Update an existing type
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *         description: The ID of the type to update
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               name:
+ *                 type: string
+ *                 example: "Updated type name"
+ *     responses:
+ *       200:
+ *         description: Type updated successfully
+ *       400:
+ *         description: Invalid ID or missing required field
+ *       404:
+ *         description: Type not found
+ */
+router.put("/types/:id", TypeController.updateType);
 
-    const newType = await prisma.type.create({
-      data: { name },
-    });
-
-    res
-      .status(201)
-      .json({ message: "Type created successfully", type: newType });
-  } catch (error) {
-    console.error("Error creating type:", error);
-    res.status(500).json({ error: "Failed to create type", details: error });
-  }
-});
+/**
+ * @swagger
+ * /api/types/{id}:
+ *   delete:
+ *     tags:
+ *       - Types
+ *     summary: Delete a type
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *         description: The ID of the type to delete
+ *     responses:
+ *       204:
+ *         description: Type deleted successfully
+ *       400:
+ *         description: Invalid ID format
+ *       404:
+ *         description: Type not found
+ */
+router.delete("/types/:id", TypeController.deleteType);
 
 export default router;

--- a/src/schemas/events.schema.ts
+++ b/src/schemas/events.schema.ts
@@ -1,7 +1,7 @@
 import Joi from "joi";
 
 export const eventQuerySchema = Joi.object({
-  status: Joi.string().valid("moderated").optional(),
+  status: Joi.string().valid("moderated", "unmoderated").optional(),
   type: Joi.number().integer().optional(),
   startDate: Joi.date().iso().optional(),
   endDate: Joi.date()

--- a/src/schemas/types.schema.ts
+++ b/src/schemas/types.schema.ts
@@ -1,0 +1,13 @@
+import Joi from "joi";
+
+export const typeSchema = Joi.object({
+  name: Joi.string().min(3).max(50).required(),
+});
+
+export const typeIdSchema = Joi.object({
+  id: Joi.number().integer().positive().required().messages({
+    "number.base": "Type ID must be a number",
+    "number.integer": "Type ID must be an integer",
+    "number.positive": "Type ID must be a positive integer",
+  }),
+});

--- a/src/schemas/types.schema.ts
+++ b/src/schemas/types.schema.ts
@@ -4,6 +4,11 @@ export const typeSchema = Joi.object({
   name: Joi.string().min(3).max(50).required(),
 });
 
+export const paginationSchema = Joi.object({
+  page: Joi.number().integer().min(1).default(1),
+  pageSize: Joi.number().integer().min(1).max(100).default(10),
+});
+
 export const typeIdSchema = Joi.object({
   id: Joi.number().integer().positive().required().messages({
     "number.base": "Type ID must be a number",

--- a/src/services/types.service.ts
+++ b/src/services/types.service.ts
@@ -1,0 +1,23 @@
+import { TypeRepository } from "../repositories/types.repository";
+
+export class TypeService {
+  static async getTypes() {
+    return TypeRepository.getTypes();
+  }
+
+  static async getTypeById(id: number) {
+    return TypeRepository.getTypeById(id);
+  }
+
+  static async createType(name: string) {
+    return TypeRepository.createType(name);
+  }
+
+  static async updateType(id: number, data: { name: string }) {
+    return TypeRepository.updateType(id, data);
+  }
+
+  static async deleteType(id: number) {
+    return TypeRepository.deleteType(id);
+  }
+}

--- a/src/services/types.service.ts
+++ b/src/services/types.service.ts
@@ -1,8 +1,8 @@
 import { TypeRepository } from "../repositories/types.repository";
 
 export class TypeService {
-  static async getTypes() {
-    return TypeRepository.getTypes();
+  static async getTypes(filters: any) {
+    return TypeRepository.getTypes(filters);
   }
 
   static async getTypeById(id: number) {

--- a/src/services/types.service.ts
+++ b/src/services/types.service.ts
@@ -20,4 +20,12 @@ export class TypeService {
   static async deleteType(id: number) {
     return TypeRepository.deleteType(id);
   }
+
+  static async typeExists(name: string) {
+    return TypeRepository.typeExists(name);
+  }
+
+  static async isUsedByEvents(id: number) {
+    return TypeRepository.isUsedByEvents(id);
+  }
 }


### PR DESCRIPTION
---
name: 'Pull Request for feature types'
title: "[Feature] types GET, POST, PUT, DELETE"
labels: 'feature'
assignees: @julgndr16 
---

## 📌 **Description**
This pull request implements the /api/types endpoints to manage event types. The following operations are now supported:
- GET /api/types → Retrieve all event types (with pagination).
- GET /api/types/{id} → Retrieve a specific event type by ID.
- POST /api/types → Create a new event type (with validation and uniqueness constraints).
- PUT /api/types/{id} → Update an existing event type (with validation and existence check).
- DELETE /api/types/{id} → Delete an event type safely (ensuring it is not used by existing events).

## 🛠 **Changes Made**
- [x] Implemented CRUD operations (GET, POST, PUT, DELETE) for event types using Prisma.
- [x] Added input validation using Joi to ensure data integrity.
- [x] Implemented pagination for GET /api/types using pageSize and page query parameters.
- [x] Enhanced error handling for missing, invalid, or conflicting data.
- [x] Prevented deletion of event types if they are associated with existing events.
- [x] Updated Swagger documentation for /api/types endpoints.
- [x] Postman tests

## 📂 **Related Issues**

Link any related issues that this merge request addresses:

- Closes #13 
