### PR TITLE
Feature/post participations

### DIFF
--- a/postman/tests.participations.json
+++ b/postman/tests.participations.json
@@ -1,0 +1,479 @@
+{
+  "info": {
+    "_postman_id": "4c8bdc02-c964-49ec-9a6f-a5c2ec96b7de",
+    "name": "Participations",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "32481832"
+  },
+  "item": [
+    {
+      "name": "/api/participations/users/{userId}/events/{eventId}",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "url": {
+          "raw": "localhost:3000/api/participations/users/5/events/35",
+          "host": ["localhost"],
+          "port": "3000",
+          "path": ["api", "participations", "users", "5", "events", "35"]
+        }
+      },
+      "response": [
+        {
+          "name": "/api/participations/users/{userId}/events/{eventId} error 400 must be number Copy",
+          "originalRequest": {
+            "method": "POST",
+            "header": [],
+            "url": {
+              "raw": "localhost:3000/api/participations/users/5/events/35",
+              "host": ["localhost"],
+              "port": "3000",
+              "path": ["api", "participations", "users", "5", "events", "35"]
+            }
+          },
+          "status": "Created",
+          "code": 201,
+          "_postman_previewlanguage": "json",
+          "header": [
+            {
+              "key": "X-Powered-By",
+              "value": "Express"
+            },
+            {
+              "key": "Content-Type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "key": "Content-Length",
+              "value": "2"
+            },
+            {
+              "key": "ETag",
+              "value": "W/\"2-vyGp6PvFo4RvsFtPoIWeCReyIC8\""
+            },
+            {
+              "key": "Date",
+              "value": "Fri, 21 Mar 2025 16:53:46 GMT"
+            },
+            {
+              "key": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "key": "Keep-Alive",
+              "value": "timeout=5"
+            }
+          ],
+          "cookie": [],
+          "body": "{}"
+        }
+      ]
+    },
+    {
+      "name": "/api/participations/users/{userId}/events/{eventId} error 400 user already participates in event",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "url": {
+          "raw": "localhost:3000/api/participations/users/2/events/35",
+          "host": ["localhost"],
+          "port": "3000",
+          "path": ["api", "participations", "users", "2", "events", "35"]
+        }
+      },
+      "response": [
+        {
+          "name": "New Request",
+          "originalRequest": {
+            "method": "POST",
+            "header": [],
+            "url": {
+              "raw": "localhost:3000/api/participations/users/2/events/35",
+              "host": ["localhost"],
+              "port": "3000",
+              "path": ["api", "participations", "users", "2", "events", "35"]
+            }
+          },
+          "status": "Bad Request",
+          "code": 400,
+          "_postman_previewlanguage": "json",
+          "header": [
+            {
+              "key": "X-Powered-By",
+              "value": "Express"
+            },
+            {
+              "key": "Content-Type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "key": "Content-Length",
+              "value": "71"
+            },
+            {
+              "key": "ETag",
+              "value": "W/\"47-pqHm8jPNGnG7nNVdJ6fL3KMB2Nc\""
+            },
+            {
+              "key": "Date",
+              "value": "Fri, 21 Mar 2025 16:52:30 GMT"
+            },
+            {
+              "key": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "key": "Keep-Alive",
+              "value": "timeout=5"
+            }
+          ],
+          "cookie": [],
+          "body": "{\n    \"status\": 400,\n    \"message\": \"User 2 is already participating in event 35.\"\n}"
+        }
+      ]
+    },
+    {
+      "name": "/api/participations/users/{userId}/events/{eventId} error 400 must be number",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "url": {
+          "raw": "localhost:3000/api/participations/users/{userId}/events/{eventId}",
+          "host": ["localhost"],
+          "port": "3000",
+          "path": [
+            "api",
+            "participations",
+            "users",
+            "{userId}",
+            "events",
+            "{eventId}"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "/api/participations/users/{userId}/events/{eventId} error 400 participation denied startDate",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "url": {
+          "raw": "localhost:3000/api/participations/users/{userId}/events/{eventId}",
+          "host": ["localhost"],
+          "port": "3000",
+          "path": [
+            "api",
+            "participations",
+            "users",
+            "{userId}",
+            "events",
+            "{eventId}"
+          ]
+        }
+      },
+      "response": [
+        {
+          "name": "/api/participations/users/{userId}/events/{eventId} error 400 must be number Copy",
+          "originalRequest": {
+            "method": "POST",
+            "header": [],
+            "url": {
+              "raw": "localhost:3000/api/participations/users/2/events/37",
+              "host": ["localhost"],
+              "port": "3000",
+              "path": ["api", "participations", "users", "2", "events", "37"]
+            }
+          },
+          "status": "Bad Request",
+          "code": 400,
+          "_postman_previewlanguage": "json",
+          "header": [
+            {
+              "key": "X-Powered-By",
+              "value": "Express"
+            },
+            {
+              "key": "Content-Type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "key": "Content-Length",
+              "value": "78"
+            },
+            {
+              "key": "ETag",
+              "value": "W/\"4e-4DaZ+l1M9dzLI+MaOm34C1pqMks\""
+            },
+            {
+              "key": "Date",
+              "value": "Fri, 21 Mar 2025 16:57:17 GMT"
+            },
+            {
+              "key": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "key": "Keep-Alive",
+              "value": "timeout=5"
+            }
+          ],
+          "cookie": [],
+          "body": "{\n    \"status\": 400,\n    \"message\": \"Participation denied: Event 37 has already started.\"\n}"
+        }
+      ]
+    },
+    {
+      "name": "/api/participations/users/{userId}/events/{eventId} error 404 user not existing",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "url": {
+          "raw": "localhost:3000/api/participations/users/50/events/35",
+          "host": ["localhost"],
+          "port": "3000",
+          "path": ["api", "participations", "users", "50", "events", "35"]
+        }
+      },
+      "response": [
+        {
+          "name": "New Request",
+          "originalRequest": {
+            "method": "POST",
+            "header": [],
+            "url": {
+              "raw": "localhost:3000/api/participations/users/50/events/35",
+              "host": ["localhost"],
+              "port": "3000",
+              "path": ["api", "participations", "users", "50", "events", "35"]
+            }
+          },
+          "status": "Not Found",
+          "code": 404,
+          "_postman_previewlanguage": "json",
+          "header": [
+            {
+              "key": "X-Powered-By",
+              "value": "Express"
+            },
+            {
+              "key": "Content-Type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "key": "Content-Length",
+              "value": "45"
+            },
+            {
+              "key": "ETag",
+              "value": "W/\"2d-cVqp3wKOsFmX2Xr496SbKj4bRGI\""
+            },
+            {
+              "key": "Date",
+              "value": "Fri, 21 Mar 2025 16:55:18 GMT"
+            },
+            {
+              "key": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "key": "Keep-Alive",
+              "value": "timeout=5"
+            }
+          ],
+          "cookie": [],
+          "body": "{\n    \"status\": 404,\n    \"message\": \"User 50 not found.\"\n}"
+        }
+      ]
+    },
+    {
+      "name": "/api/participations/users/{userId}/events/{eventId} error 404 event not existing",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "url": {
+          "raw": "localhost:3000/api/participations/users/50/events/35",
+          "host": ["localhost"],
+          "port": "3000",
+          "path": ["api", "participations", "users", "50", "events", "35"]
+        }
+      },
+      "response": [
+        {
+          "name": "/api/participations/users/{userId}/events/{eventId} error 404 user not existing Copy",
+          "originalRequest": {
+            "method": "POST",
+            "header": [],
+            "url": {
+              "raw": "localhost:3000/api/participations/users/5/events/100",
+              "host": ["localhost"],
+              "port": "3000",
+              "path": ["api", "participations", "users", "5", "events", "100"]
+            }
+          },
+          "status": "Not Found",
+          "code": 404,
+          "_postman_previewlanguage": "json",
+          "header": [
+            {
+              "key": "X-Powered-By",
+              "value": "Express"
+            },
+            {
+              "key": "Content-Type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "key": "Content-Length",
+              "value": "47"
+            },
+            {
+              "key": "ETag",
+              "value": "W/\"2f-X+7sEbulI5SriSgm+qWN3hJd6ms\""
+            },
+            {
+              "key": "Date",
+              "value": "Fri, 21 Mar 2025 16:56:04 GMT"
+            },
+            {
+              "key": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "key": "Keep-Alive",
+              "value": "timeout=5"
+            }
+          ],
+          "cookie": [],
+          "body": "{\n    \"status\": 404,\n    \"message\": \"Event 100 not found.\"\n}"
+        }
+      ]
+    },
+    {
+      "name": "/api/participations/users/{userId}/events/{eventId} error 400 event full",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "url": {
+          "raw": "localhost:3000/api/participations/users/2/events/33",
+          "host": ["localhost"],
+          "port": "3000",
+          "path": ["api", "participations", "users", "2", "events", "33"]
+        }
+      },
+      "response": [
+        {
+          "name": "New Request",
+          "originalRequest": {
+            "method": "POST",
+            "header": [],
+            "url": {
+              "raw": "localhost:3000/api/participations/users/2/events/33",
+              "host": ["localhost"],
+              "port": "3000",
+              "path": ["api", "participations", "users", "2", "events", "33"]
+            }
+          },
+          "status": "Bad Request",
+          "code": 400,
+          "_postman_previewlanguage": "json",
+          "header": [
+            {
+              "key": "X-Powered-By",
+              "value": "Express"
+            },
+            {
+              "key": "Content-Type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "key": "Content-Length",
+              "value": "66"
+            },
+            {
+              "key": "ETag",
+              "value": "W/\"42-UYzndQyUWNxkBZm8GLqNydiNUhI\""
+            },
+            {
+              "key": "Date",
+              "value": "Fri, 21 Mar 2025 16:58:48 GMT"
+            },
+            {
+              "key": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "key": "Keep-Alive",
+              "value": "timeout=5"
+            }
+          ],
+          "cookie": [],
+          "body": "{\n    \"status\": 400,\n    \"message\": \"Participation denied: Event 33 is full.\"\n}"
+        }
+      ]
+    },
+    {
+      "name": "/api/participations/users/{userId}/events/{eventId} error event not moderated",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "url": {
+          "raw": "localhost:3000/api/participations/users/2/events/38",
+          "host": ["localhost"],
+          "port": "3000",
+          "path": ["api", "participations", "users", "2", "events", "38"]
+        }
+      },
+      "response": [
+        {
+          "name": "New Request",
+          "originalRequest": {
+            "method": "POST",
+            "header": [],
+            "url": {
+              "raw": "localhost:3000/api/participations/users/2/events/38",
+              "host": ["localhost"],
+              "port": "3000",
+              "path": ["api", "participations", "users", "2", "events", "38"]
+            }
+          },
+          "status": "Bad Request",
+          "code": 400,
+          "_postman_previewlanguage": "json",
+          "header": [
+            {
+              "key": "X-Powered-By",
+              "value": "Express"
+            },
+            {
+              "key": "Content-Type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "key": "Content-Length",
+              "value": "75"
+            },
+            {
+              "key": "ETag",
+              "value": "W/\"4b-LT0IQJjIapviKNPuTfX9ZzYGl8c\""
+            },
+            {
+              "key": "Date",
+              "value": "Fri, 21 Mar 2025 17:00:11 GMT"
+            },
+            {
+              "key": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "key": "Keep-Alive",
+              "value": "timeout=5"
+            }
+          ],
+          "cookie": [],
+          "body": "{\n    \"status\": 400,\n    \"message\": \"Participation denied: Event 38 is not moderated.\"\n}"
+        }
+      ]
+    }
+  ]
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -53,7 +53,7 @@ model Participation {
   eventId Int
   user User @relation(fields: [userId], references: [id])
   event Event @relation(fields: [eventId], references: [id])
-  @@unique([userId, eventId])
+  @@id([userId, eventId])
 }
 
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,6 +4,7 @@ import setupSwagger from "./swaggerConfig";
 import eventRoutes from "./routes/events.route";
 import userRoutes from "./routes/users.route";
 import typeRoutes from "./routes/types.route";
+import participationRoutes from "./routes/participations.route";
 
 const app = express();
 const port = 3000;
@@ -23,6 +24,7 @@ app.post("/", (req, res) => {
 app.use("/api", eventRoutes);
 app.use("/api", userRoutes);
 app.use("/api", typeRoutes);
+app.use("/api", participationRoutes);
 
 // middlewares
 app.use(errorHandler);

--- a/src/controllers/participations.controller.ts
+++ b/src/controllers/participations.controller.ts
@@ -1,0 +1,29 @@
+import { Request, Response } from "express";
+import { participationSchema } from "../schemas/participations.schema";
+import { ParticipationService } from "../services/participations.service";
+
+export class ParticipationController {
+  static async participate(req: Request, res: Response) {
+    try {
+      const { userId, eventId } = req.params;
+      const { error } = participationSchema.validate({
+        idUser: Number(userId),
+        idEvent: Number(eventId),
+      });
+      if (error) {
+        res.status(400).send({ error: error.details[0].message });
+        return;
+      }
+      const participation = await ParticipationService.participate(
+        Number(userId),
+        Number(eventId),
+      );
+      res.status(201).json(participation);
+    } catch (error) {
+      const status = error.status || 500;
+      const message = error.message || "Internal server error";
+
+      res.status(status).json({ status, message });
+    }
+  }
+}

--- a/src/entities/participations.entity.ts
+++ b/src/entities/participations.entity.ts
@@ -1,0 +1,13 @@
+export class Participation {
+  constructor(
+    public idUser: number,
+    public idEvent: number,
+  ) {}
+
+  static fromPrisma(prismaParticipation: any): Participation {
+    return new Participation(
+      prismaParticipation.idUser,
+      prismaParticipation.idEvent,
+    );
+  }
+}

--- a/src/repositories/participations.repository.ts
+++ b/src/repositories/participations.repository.ts
@@ -1,0 +1,21 @@
+import { prisma } from "../prismaClient";
+import { Participation } from "../entities/participations.entity";
+
+export class ParticipationRepository {
+  static async participate(
+    userId: number,
+    eventId: number,
+  ): Promise<Participation> {
+    const participation = await prisma.participation.create({
+      data: { userId: userId, eventId: eventId },
+    });
+
+    return Participation.fromPrisma(participation);
+  }
+
+  static async countParticipants(eventId: number) {
+    return prisma.participation.count({
+      where: { eventId },
+    });
+  }
+}

--- a/src/repositories/users.repository.ts
+++ b/src/repositories/users.repository.ts
@@ -1,6 +1,6 @@
 import { prisma } from "../prismaClient";
 import { User } from "../entities/users.entitie";
-import { PrismaClient, Prisma } from "@prisma/client";
+import { Prisma } from "@prisma/client";
 
 export class UsersRepository {
   static async createUser(userData: {
@@ -117,5 +117,14 @@ export class UsersRepository {
     });
 
     return prismaUser ? User.fromPrismaInternal(prismaUser) : null;
+  }
+
+  //getuserbyid
+  static async getUserById(userId: number): Promise<User | null> {
+    const prismaUser = await prisma.user.findUnique({
+      where: { id: userId },
+    });
+
+    return prismaUser ? User.fromPrismaExternal(prismaUser) : null;
   }
 }

--- a/src/routes/events.route.ts
+++ b/src/routes/events.route.ts
@@ -84,41 +84,6 @@ const router = Router();
  */
 
 router.get("/events", EventController.getEvents);
-/**
- * @swagger
- * components:
- *   schemas:
- *     updateEventSchema:
- *       type: object
- *       properties:
- *         name:
- *           type: string
- *           example: "Hackathon 2025"
- *         startDate:
- *           type: string
- *           format: date-time
- *           example: "2025-04-01T09:00:00.000Z"
- *         endDate:
- *           type: string
- *           format: date-time
- *           example: "2025-04-02T18:00:00.000Z"
- *         location:
- *           type: string
- *           example: "Paris"
- *         maxParticipants:
- *           type: integer
- *           example: 100
- *         picture:
- *           type: string
- *           format: uri
- *           example: "https://example.com/event.jpg"
- *         description:
- *           type: string
- *           example: "A great tech event"
- *         typeId:
- *           type: integer
- *           example: 2
- */
 
 /**
  * @swagger
@@ -250,45 +215,6 @@ router.post("/events", EventController.createEvent);
  *                   example: "An unexpected error occurred"
  */
 router.get("/events/:id", EventController.getEventById);
-
-/**
- * @swagger
- * components:
- *   schemas:
- *     updateEventSchema:
- *       type: object
- *       properties:
- *         name:
- *           type: string
- *           example: "Hackathon 2025"
- *         responsableId:
- *           type: integer
- *           example: 1
- *         startDate:
- *           type: string
- *           format: date-time
- *           example: "2025-04-01T09:00:00.000Z"
- *         endDate:
- *           type: string
- *           format: date-time
- *           example: "2025-04-02T18:00:00.000Z"
- *         location:
- *           type: string
- *           example: "Paris"
- *         maxParticipants:
- *           type: integer
- *           example: 100
- *         picture:
- *           type: string
- *           format: uri
- *           example: "https://example.com/event.jpg"
- *         description:
- *           type: string
- *           example: "A great tech event"
- *         typeId:
- *           type: integer
- *           example: 2
- */
 
 /**
  * @swagger

--- a/src/routes/participations.route.ts
+++ b/src/routes/participations.route.ts
@@ -1,0 +1,38 @@
+import { Router } from "express";
+import { ParticipationController } from "../controllers/participations.controller";
+const router = Router();
+
+/**
+ * @swagger
+ * /api/participations/users/{userId}/events/{eventId}:
+ *   post:
+ *     tags:
+ *       - Participations
+ *     summary: User participation in an event
+ *     parameters:
+ *       - in: path
+ *         name: userId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *         description: "ID of the user"
+ *       - in: path
+ *         name: eventId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *         description: "ID of the event"
+ *     responses:
+ *       201:
+ *         description: "User successfully added to the event"
+ *       400:
+ *         description: "Invalid request parameters or event is not moderated"
+ *       404:
+ *         description: "Event not found"
+ */
+router.post(
+  "/participations/users/:userId/events/:eventId",
+  ParticipationController.participate,
+);
+
+export default router;

--- a/src/schemas/participations.schema.ts
+++ b/src/schemas/participations.schema.ts
@@ -1,0 +1,6 @@
+import Joi from "joi";
+
+export const participationSchema = Joi.object({
+  idUser: Joi.number().integer().positive().required(),
+  idEvent: Joi.number().integer().positive().required(),
+});

--- a/src/services/participations.service.ts
+++ b/src/services/participations.service.ts
@@ -1,0 +1,50 @@
+import { ParticipationRepository } from "../repositories/participations.repository";
+import { EventRepository } from "../repositories/events.repository";
+import { UsersRepository } from "../repositories/users.repository";
+import { Prisma } from "@prisma/client";
+
+export class ParticipationService {
+  static async participate(userId: number, eventId: number) {
+    const user = await UsersRepository.getUserById(userId);
+    if (!user) {
+      throw { status: 404, message: `User ${userId} not found.` };
+    }
+    const event = await EventRepository.getEventById(eventId);
+    if (!event) {
+      throw { status: 404, message: `Event ${eventId} not found.` };
+    }
+    if (!event.isModerate) {
+      throw {
+        status: 400,
+        message: `Participation denied: Event ${eventId} is not moderated.`,
+      };
+    }
+
+    const currentParticipants =
+      await ParticipationRepository.countParticipants(eventId);
+    if (currentParticipants >= event.maxParticipants) {
+      throw {
+        status: 400,
+        message: `Participation denied: Event ${eventId} is full.`,
+      };
+    }
+
+    try {
+      return await ParticipationRepository.participate(userId, eventId);
+    } catch (error) {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === "P2002"
+      ) {
+        throw {
+          status: 400,
+          message: `User ${userId} is already participating in event ${eventId}.`,
+        };
+      }
+      throw {
+        status: 500,
+        message: `An unexpected error occurred: ${error.message}`,
+      };
+    }
+  }
+}

--- a/src/services/participations.service.ts
+++ b/src/services/participations.service.ts
@@ -19,6 +19,13 @@ export class ParticipationService {
         message: `Participation denied: Event ${eventId} is not moderated.`,
       };
     }
+    const currentDate = new Date();
+    if (event.startDate < currentDate) {
+      throw {
+        status: 400,
+        message: `Participation denied: Event ${eventId} has already started.`,
+      };
+    }
 
     const currentParticipants =
       await ParticipationRepository.countParticipants(eventId);

--- a/src/swaggerConfig.ts
+++ b/src/swaggerConfig.ts
@@ -22,6 +22,10 @@ const swaggerDefinition = {
       name: "Types",
       description: "Types management",
     },
+    {
+      name: "Participations",
+      description: "Participations management",
+    },
   ],
 };
 


### PR DESCRIPTION
---
name: 'Pull Request for POST participations'
title: "[Feature] Add participation in an event"
labels: 'feature'
assignees: @julgndr16 
---

## 📌 **Description**
Implementation of the` POST /api/participations/users/{userId}/events/{eventId} `endpoint, allowing users to request participation in an event. A user can only participate in the event if the event is moderated.

## 🛠 **Changes Made**
- [x] Added the `POST /api/participations/users/{userId}/events/{eventId} `endpoint
- [x] Checked the isModerate flag of the event before allowing participation
- [x] Ensured that a user can only participate once in an event
- [x] Verified that the event has available spots (`maxParticipants`) and its `startDate `is in the future
- [x] Added appropriate error handling for non-moderated events, invalid parameters, and duplicate participation requests
- [x]  Updated Swagger documentation for this endpoint
- [x] Postman tests

## 📂 **Related Issues**

Link any related issues that this merge request addresses:

- Closes #18 
