### PR TITLE
Fix/validation inputs /events routes

### DIFF
--- a/src/controllers/events.controller.ts
+++ b/src/controllers/events.controller.ts
@@ -5,8 +5,8 @@ import {
   eventIdSchema,
   eventSchema,
 } from "../schemas/events.schema";
-import { prisma } from "../prismaClient";
 import { TypeService } from "../services/types.service";
+import { UsersService } from "../services/users.service";
 
 export class EventController {
   static async getEvents(req: Request, res: Response) {
@@ -51,36 +51,23 @@ export class EventController {
       }
 
       const { responsableId, typeId } = req.body;
-
-      //TODO : modify if responsableId or typeId are invalid with the service
-
-      // const { responsableId, typeId } = value;
-      //
-      // const responsable = await ResponsableService.findById(responsableId);
-      // if (!responsable) {
-      //   return res.status(400).json({
-      //     error: "Invalid responsibleId",
-      //     message: `No responsable found with ID ${responsableId}`,
-      //   });
-      // }
-      //
-      const eventType = await TypeService.getTypeById(typeId);
-      if (!eventType) {
-        res.status(404).json({ error: "Type not found" });
-        return;
-      }
-      const responsable = await prisma.user.findUnique({
-        where: { id: responsableId },
-      });
-
+      const responsable = await UsersService.getUserById(responsableId);
       if (!responsable) {
-        res.status(400).json({
+        res.status(404).json({
           error: "Invalid responsableId",
           message: `No user found with ID ${responsableId}`,
         });
         return;
       }
 
+      const eventType = await TypeService.getTypeById(typeId);
+      if (!eventType) {
+        res.status(404).json({
+          error: "Invalid typeId",
+          message: `No event type found with ID ${typeId}`,
+        });
+        return;
+      }
       const newEvent = await EventService.createEvent(value);
       res.status(201).json(newEvent);
     } catch (error) {
@@ -103,7 +90,10 @@ export class EventController {
 
       const event = await EventService.getEventById(eventId);
       if (!event) {
-        res.status(404).json({ error: "Event not found or access denied" });
+        res.status(404).json({
+          error: "Event not found",
+          message: `No event found with ID ${eventId}`,
+        });
         return;
       }
       res.status(200).json(event);
@@ -123,7 +113,10 @@ export class EventController {
 
       const existingEvent = await EventService.getEventById(eventId);
       if (!existingEvent) {
-        res.status(404).json({ error: "Event not found" });
+        res.status(404).json({
+          error: "Event not found",
+          message: `No event found with ID ${eventId}`,
+        });
         return;
       }
       const { error: bodyError, value } = eventSchema.validate(req.body, {
@@ -139,31 +132,19 @@ export class EventController {
 
       const { responsableId, typeId } = req.body;
 
-      //TODO : modify if responsableId or typeId are invalid with the service
-
-      // const { responsableId, typeId } = value;
-      //
-      // const responsable = await ResponsableService.findById(responsableId);
-      // if (!responsable) {
-      //   return res.status(400).json({
-      //     error: "Invalid responsibleId",
-      //     message: `No responsable found with ID ${responsableId}`,
-      //   });
-      // }
-      const eventType = await TypeService.getTypeById(typeId);
-      if (!eventType) {
-        res.status(404).json({ error: "Type not found" });
+      const responsable = await UsersService.getUserById(responsableId);
+      if (!responsable) {
+        res.status(404).json({
+          error: "Invalid responsibleId",
+          message: `No responsable found with ID ${responsableId}`,
+        });
         return;
       }
-
-      const responsable = await prisma.user.findUnique({
-        where: { id: responsableId },
-      });
-
-      if (!responsable) {
-        res.status(400).json({
-          error: "Invalid responsableId",
-          message: `No user found with ID ${responsableId}`,
+      const eventType = await TypeService.getTypeById(typeId);
+      if (!eventType) {
+        res.status(404).json({
+          error: "Invalid typeId",
+          message: `No event type found with ID ${typeId}`,
         });
         return;
       }

--- a/src/controllers/events.controller.ts
+++ b/src/controllers/events.controller.ts
@@ -1,7 +1,12 @@
 import { Request, Response } from "express";
 import { EventService } from "../services/events.service";
-import { eventQuerySchema, eventIdSchema, eventSchema } from "../schemas/events.schema";
+import {
+  eventQuerySchema,
+  eventIdSchema,
+  eventSchema,
+} from "../schemas/events.schema";
 import { prisma } from "../prismaClient";
+import { TypeService } from "../services/types.service";
 
 export class EventController {
   static async getEvents(req: Request, res: Response) {
@@ -59,13 +64,11 @@ export class EventController {
       //   });
       // }
       //
-      // const eventType = await EventTypeService.findById(typeId);
-      // if (!eventType) {
-      //   return res.status(400).json({
-      //     error: "Invalid typeId",
-      //     message: `No event type found with ID ${typeId}`,
-      //   });
-      // }
+      const eventType = await TypeService.getTypeById(typeId);
+      if (!eventType) {
+        res.status(404).json({ error: "Type not found" });
+        return;
+      }
       const responsable = await prisma.user.findUnique({
         where: { id: responsableId },
       });
@@ -74,18 +77,6 @@ export class EventController {
         res.status(400).json({
           error: "Invalid responsableId",
           message: `No user found with ID ${responsableId}`,
-        });
-        return;
-      }
-
-      const eventType = await prisma.type.findUnique({
-        where: { id: typeId },
-      });
-
-      if (!eventType) {
-        res.status(400).json({
-          error: "Invalid typeId",
-          message: `No event type found with ID ${typeId}`,
         });
         return;
       }
@@ -159,14 +150,12 @@ export class EventController {
       //     message: `No responsable found with ID ${responsableId}`,
       //   });
       // }
-      //
-      // const eventType = await EventTypeService.findById(typeId);
-      // if (!eventType) {
-      //   return res.status(400).json({
-      //     error: "Invalid typeId",
-      //     message: `No event type found with ID ${typeId}`,
-      //   });
-      // }
+      const eventType = await TypeService.getTypeById(typeId);
+      if (!eventType) {
+        res.status(404).json({ error: "Type not found" });
+        return;
+      }
+
       const responsable = await prisma.user.findUnique({
         where: { id: responsableId },
       });
@@ -179,17 +168,6 @@ export class EventController {
         return;
       }
 
-      const eventType = await prisma.type.findUnique({
-        where: { id: typeId },
-      });
-
-      if (!eventType) {
-        res.status(400).json({
-          error: "Invalid typeId",
-          message: `No event type found with ID ${typeId}`,
-        });
-        return;
-      }
       const event = await EventService.updateEvent(eventId, value);
 
       res.status(200).json(event);
@@ -201,7 +179,7 @@ export class EventController {
       res.status(500).send({ error: "Internal server error" });
     }
   }
-   static async removeEvent(req: Request, res: Response) {
+  static async removeEvent(req: Request, res: Response) {
     try {
       const { error } = eventIdSchema.validate(req.params);
 

--- a/src/services/users.service.ts
+++ b/src/services/users.service.ts
@@ -76,4 +76,8 @@ export class UsersService {
   static async getUsers(filters: any) {
     return await UsersRepository.getUsers(filters);
   }
+
+  static async getUserById(userId: number) {
+    return await UsersRepository.getUserById(userId);
+  }
 }


### PR DESCRIPTION
---
name: 'Pull Request for fix validation inputs responsableId and typeId in the POST /events and PUT /events/:id'
title: "[Fix] Validation inputs /events routes"
labels: '\fix'
assignees: '@camsbqt'
---

## 📌 **Description**

Modify the validation of responsableIdand typeId in the `POST /events` and `PUT /events/:id` routes by using their services (users.service and types.service) to improve code reusability.

## 🛠 **Changes Made**

List the key modifications and improvements:

- [ ] Add the function getUserByid on the UsersService
- [x] Use `UsersService.getUserById(userId)` instead of `prisma.user.findUnique`
- [x] Use `TypeService.getTypeById(typeId)` instead of `prisma.type.findUnique`
- [ ] Modify errors messages `POST /events` and `PUT /events/:id`


## 📂 **Related Issues**

Link any related issues that this merge request addresses:

- Closes #21 

