### PR TITLE
Feature/manage access event

### DIFF
--- a/src/controllers/events.controller.ts
+++ b/src/controllers/events.controller.ts
@@ -187,6 +187,15 @@ export class EventController {
         res.status(404).json({ error: "Event not found" });
         return;
       }
+
+      const userId = (req as any).user?.userId;
+      if (userId !== event.responsableId) {
+        res.status(403).json({
+          error: "Access denied",
+          message: "You are not allowed to delete this event",
+        });
+        return;
+      }
       await EventService.removeEvent(eventId);
 
       res.status(200).json({ message: "Event deleted successfully" });

--- a/src/controllers/events.controller.ts
+++ b/src/controllers/events.controller.ts
@@ -221,6 +221,16 @@ export class EventController {
         });
         return;
       }
+
+      const userId = (req as any).user?.userId;
+      if (userId !== event.responsableId) {
+        res.status(403).json({
+          error: "Access denied",
+          message: "You are not allowed to access this event",
+        });
+        return;
+      }
+
       const { error: errorPage, value } = paginationSchema.validate(req.query);
       if (errorPage) {
         res.status(400).json({ error: errorPage.details[0].message });

--- a/src/controllers/events.controller.ts
+++ b/src/controllers/events.controller.ts
@@ -152,6 +152,15 @@ export class EventController {
         return;
       }
 
+      const userId = (req as any).user?.userId;
+      if (userId !== existingEvent.responsableId) {
+        res.status(403).json({
+          error: "Access denied",
+          message: "You are not allowed to update this event",
+        });
+        return;
+      }
+
       const event = await EventService.updateEvent(eventId, value);
 
       res.status(200).json(event);

--- a/src/middlewares/authentication.middleware.ts
+++ b/src/middlewares/authentication.middleware.ts
@@ -48,3 +48,24 @@ export const authorizeUser = (
 
   next();
 };
+
+export const authorizeUserEvent = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void => {
+  const userIdFromToken = (req as any).user?.userId;
+  const userIdFromParams = parseInt(req.body.responsableId, 10);
+
+  if (isNaN(userIdFromParams) || userIdFromToken !== userIdFromParams) {
+    res
+      .status(403)
+      .json({
+        error:
+          "Forbidden: You are not allowed to create/modify an event for this user",
+      });
+    return;
+  }
+
+  next();
+};

--- a/src/routes/events.route.ts
+++ b/src/routes/events.route.ts
@@ -350,7 +350,6 @@ router.delete("/events/:id", authenticateUser, EventController.removeEvent);
 router.get(
   "/events/:id/participations",
   authenticateUser,
-  authorizeUserEvent,
   EventController.getParticipations,
 );
 

--- a/src/routes/events.route.ts
+++ b/src/routes/events.route.ts
@@ -313,12 +313,7 @@ router.put(
  *         description: Event deleted successfully
  */
 
-router.delete(
-  "/events/:id",
-  authenticateUser,
-  authorizeUserEvent,
-  EventController.removeEvent,
-);
+router.delete("/events/:id", authenticateUser, EventController.removeEvent);
 
 /**
  * @swagger

--- a/src/routes/events.route.ts
+++ b/src/routes/events.route.ts
@@ -1,5 +1,10 @@
 import { Router } from "express";
 import { EventController } from "../controllers/events.controller";
+import {
+  authenticateUser,
+  authorizeUser,
+  authorizeUserEvent,
+} from "../middlewares/authentication.middleware";
 
 const router = Router();
 
@@ -92,6 +97,8 @@ router.get("/events", EventController.getEvents);
  *     tags:
  *       - Events
  *     summary: Create a new event
+ *     security:
+ *       - BearerAuth: []
  *     requestBody:
  *       required: true
  *       content:
@@ -125,7 +132,12 @@ router.get("/events", EventController.getEvents);
  *       500:
  *         description: Server error
  */
-router.post("/events", EventController.createEvent);
+router.post(
+  "/events",
+  authenticateUser,
+  authorizeUserEvent,
+  EventController.createEvent,
+);
 
 /**
  * @swagger
@@ -248,6 +260,8 @@ router.get("/events/:id", EventController.getEventById);
  *     tags:
  *       - Events
  *     summary: Update an existing event
+ *     security:
+ *       - BearerAuth: []
  *     parameters:
  *       - name: id
  *         in: path
@@ -271,7 +285,12 @@ router.get("/events/:id", EventController.getEventById);
  *       500:
  *         description: Internal server error
  */
-router.put("/events/:id", EventController.updateEvent);
+router.put(
+  "/events/:id",
+  authenticateUser,
+  authorizeUserEvent,
+  EventController.updateEvent,
+);
 
 /**
  * @swagger
@@ -280,6 +299,8 @@ router.put("/events/:id", EventController.updateEvent);
  *     tags:
  *       - Events
  *     summary: Remove event by ID
+ *     security:
+ *       - BearerAuth: []
  *     parameters:
  *       - name: id
  *         in: path
@@ -292,7 +313,12 @@ router.put("/events/:id", EventController.updateEvent);
  *         description: Event deleted successfully
  */
 
-router.delete("/events/:id", EventController.removeEvent);
+router.delete(
+  "/events/:id",
+  authenticateUser,
+  authorizeUserEvent,
+  EventController.removeEvent,
+);
 
 /**
  * @swagger
@@ -301,6 +327,8 @@ router.delete("/events/:id", EventController.removeEvent);
  *     tags:
  *       - Events
  *     summary: Get the list of participants for an event
+ *     security:
+ *       - BearerAuth: []
  *     parameters:
  *          - name: id
  *            in: path
@@ -324,6 +352,11 @@ router.delete("/events/:id", EventController.removeEvent);
  *       204:
  *         description: Event deleted successfully
  */
-router.get("/events/:id/participations", EventController.getParticipations);
+router.get(
+  "/events/:id/participations",
+  authenticateUser,
+  authorizeUserEvent,
+  EventController.getParticipations,
+);
 
 export default router;


### PR DESCRIPTION
---
name: 'Pull Request for manage access to /events route'
title: "[Feature] Manage the access to /events routes"
labels: 'feature'
assignees: '@camsbqt'
---

## 📌 **Description**

Implement role-based access control for event routes. This will restrict access to specific routes based on the user's role (responsible, or simple user).

## 🛠 **Changes Made**

List the key modifications and improvements:

-   [x] Modify the following API endpoints and routes to enforce role-based access control:
    -   [x]  `POST/api/events/`: you can only create events for which you are responsible
    -   [x] `PUT /api/events/{id}`: Allow responsible users.
    -   [x] `DELETE /api/events/{id}`: Allow responsible users.
    -   [x] `GET /api/events/{id}/participations`: Allow  responsible users.
- [x] Add unit and integration tests (if applicable)
- [x] Update documentation (Swagger, README, etc.)
- [x] Ensure proper validation and permission handling

## 📂 **Related Issues**

Link any related issues that this merge request addresses:

- Closes #26 
- Related to #IssueNumber


