### PR TITLE
Feature/manage access participation

### DIFF
--- a/src/controllers/participations.controller.ts
+++ b/src/controllers/participations.controller.ts
@@ -49,6 +49,14 @@ export class ParticipationController {
         });
         return;
       }
+      const userIdFromToken = (req as any).user?.userId;
+      console.log(userIdFromToken);
+      if (userIdFromToken !== Number(userId)) {
+        res.status(403).json({
+          message: "You are not authorized to cancel this participation",
+        });
+        return;
+      }
 
       await ParticipationService.cancelParticipation(
         Number(userId),

--- a/src/controllers/participations.controller.ts
+++ b/src/controllers/participations.controller.ts
@@ -14,11 +14,20 @@ export class ParticipationController {
         res.status(400).send({ error: error.details[0].message });
         return;
       }
+      const userIdFromToken = (req as any).user?.userId;
+      if (userIdFromToken !== Number(userId)) {
+        res.status(403).json({
+          message: "You are not authorized to add this user",
+        });
+        return;
+      }
       const participation = await ParticipationService.participate(
         Number(userId),
         Number(eventId),
       );
-      res.status(201).json(participation);
+      res
+        .status(201)
+        .json({ message: "User participation successfully registered" });
     } catch (error) {
       const status = error.status || 500;
       const message = error.message || "Internal server error";
@@ -50,7 +59,6 @@ export class ParticipationController {
         return;
       }
       const userIdFromToken = (req as any).user?.userId;
-      console.log(userIdFromToken);
       if (userIdFromToken !== Number(userId)) {
         res.status(403).json({
           message: "You are not authorized to cancel this participation",

--- a/src/routes/participations.route.ts
+++ b/src/routes/participations.route.ts
@@ -10,6 +10,8 @@ const router = Router();
  *     tags:
  *       - Participations
  *     summary: User participation in an event
+ *     security:
+ *       - BearerAuth: []
  *     parameters:
  *       - in: path
  *         name: userId
@@ -33,6 +35,7 @@ const router = Router();
  */
 router.post(
   "/participations/users/:userId/events/:eventId",
+  authenticateUser,
   ParticipationController.participate,
 );
 /**

--- a/src/routes/participations.route.ts
+++ b/src/routes/participations.route.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import { ParticipationController } from "../controllers/participations.controller";
+import { authenticateUser } from "../middlewares/authentication.middleware";
 const router = Router();
 
 /**
@@ -41,6 +42,8 @@ router.post(
  *     tags:
  *       - Participations
  *     summary: Cancel user participation in an event
+ *     security:
+ *       - BearerAuth: []
  *     parameters:
  *       - in: path
  *         name: userId
@@ -64,6 +67,7 @@ router.post(
  */
 router.delete(
   "/participations/users/:userId/events/:eventId",
+  authenticateUser,
   ParticipationController.cancelParticipation,
 );
 export default router;


### PR DESCRIPTION
---
name: 'Pull Request for manage access to /participations'
title: "[Feature] Manage access to /participations"
labels: 'feature'
assignees: '@camsbqt'
---

## 📌 **Description**

Implement role-based access control for participations routes. This will restrict access to specific routes based on the user's role (responsible, or simple user).

## 🛠 **Changes Made**

List the key modifications and improvements:

-   [x] Modify the following API endpoints and routes to enforce role-based access control:
    -   [x]  `POST/api/participations/users/{id}/events/{id}`: you can only add yourself to an event
    -   [x] `DELETE /api/participations/users/{id}/events/{id}`: you can only remove yourself to an event
- [ ] Add unit and integration tests (if applicable)
- [x] Update documentation (Swagger, README, etc.)
- [x] Ensure proper validation and permission handling

## 📂 **Related Issues**

Link any related issues that this merge request addresses:

- Closes #32 

