### PR TITLE
Feature/manage admin access

### DIFF
--- a/src/controllers/participations.controller.ts
+++ b/src/controllers/participations.controller.ts
@@ -14,13 +14,7 @@ export class ParticipationController {
         res.status(400).send({ error: error.details[0].message });
         return;
       }
-      const userIdFromToken = (req as any).user?.userId;
-      if (userIdFromToken !== Number(userId)) {
-        res.status(403).json({
-          message: "You are not authorized to add this user",
-        });
-        return;
-      }
+
       const participation = await ParticipationService.participate(
         Number(userId),
         Number(eventId),

--- a/src/middlewares/authentication.middleware.ts
+++ b/src/middlewares/authentication.middleware.ts
@@ -80,12 +80,14 @@ export async function authorizeAdmin(
     const user = await UsersService.getUserById(userId);
 
     if (!user || !user.isAdmin) {
-      return res.status(403).json({ message: "Admin access required" });
+      res.status(403).json({ message: "Admin access required" });
+      return;
     }
 
     next();
   } catch (error) {
-    return res.status(500).json({ message: "Internal server error" });
+    res.status(500).json({ message: "Internal server error" });
+    return;
   }
 }
 
@@ -123,12 +125,10 @@ export async function authorizeSelfOrAdmin(
     const user = await UsersService.getUserById(userIdFromToken);
 
     if (!user || (userIdFromToken !== userIdFromParams && !user.isAdmin)) {
-      res
-        .status(403)
-        .json({
-          message:
-            "Permission denied: you are not authorised to add someone else's participation or need admin rights",
-        });
+      res.status(403).json({
+        message:
+          "Permission denied: you are not authorised to add someone else's participation or need admin rights",
+      });
       return;
     }
 

--- a/src/middlewares/authentication.middleware.ts
+++ b/src/middlewares/authentication.middleware.ts
@@ -138,3 +138,24 @@ export async function authorizeSelfOrAdmin(
     return;
   }
 }
+
+export const optionalAuth = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  const authHeader = req.headers.authorization;
+
+  if (authHeader) {
+    const token = authHeader.split(" ")[1];
+
+    try {
+      const decoded = jwt.verify(token, JWT_SECRET) as { userId: number };
+      if (decoded) (req as any).user = decoded;
+    } catch (error) {
+      // Token invalide → Laisse l'utilisateur non authentifié
+    }
+  }
+
+  next();
+};

--- a/src/middlewares/authentication.middleware.ts
+++ b/src/middlewares/authentication.middleware.ts
@@ -111,3 +111,30 @@ export async function authorizeBasedOnParams(
     return res.status(500).json({ message: "Internal server error" });
   }
 }
+
+export async function authorizeSelfOrAdmin(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  try {
+    const userIdFromToken = (req as any).user.userId;
+    const userIdFromParams = parseInt(req.params.userId, 10);
+    const user = await UsersService.getUserById(userIdFromToken);
+
+    if (!user || (userIdFromToken !== userIdFromParams && !user.isAdmin)) {
+      res
+        .status(403)
+        .json({
+          message:
+            "Permission denied: you are not authorised to add someone else's participation or need admin rights",
+        });
+      return;
+    }
+
+    next();
+  } catch (error) {
+    res.status(500).json({ message: "Internal server error" });
+    return;
+  }
+}

--- a/src/routes/events.route.ts
+++ b/src/routes/events.route.ts
@@ -2,7 +2,7 @@ import { Router } from "express";
 import { EventController } from "../controllers/events.controller";
 import {
   authenticateUser,
-  authorizeUser,
+  optionalAuth,
   authorizeUserEvent,
 } from "../middlewares/authentication.middleware";
 
@@ -15,6 +15,8 @@ const router = Router();
  *     tags:
  *       - Events
  *     summary: Get the list of events
+ *     security:
+ *       - BearerAuth: []
  *     parameters:
  *       - name: status
  *         in: query
@@ -88,7 +90,7 @@ const router = Router();
  *
  */
 
-router.get("/events", EventController.getEvents);
+router.get("/events", optionalAuth, EventController.getEvents);
 
 /**
  * @swagger
@@ -146,6 +148,8 @@ router.post(
  *     tags:
  *       - Events
  *     summary: Retrieve event details by ID
+ *     security:
+ *       - BearerAuth: []
  *     parameters:
  *       - name: id
  *         in: path
@@ -226,7 +230,7 @@ router.post(
  *                   type: string
  *                   example: "An unexpected error occurred"
  */
-router.get("/events/:id", EventController.getEventById);
+router.get("/events/:id", optionalAuth, EventController.getEventById);
 
 /**
  * @swagger

--- a/src/routes/participations.route.ts
+++ b/src/routes/participations.route.ts
@@ -1,6 +1,9 @@
 import { Router } from "express";
 import { ParticipationController } from "../controllers/participations.controller";
-import { authenticateUser } from "../middlewares/authentication.middleware";
+import {
+  authenticateUser,
+  authorizeSelfOrAdmin,
+} from "../middlewares/authentication.middleware";
 const router = Router();
 
 /**
@@ -36,6 +39,7 @@ const router = Router();
 router.post(
   "/participations/users/:userId/events/:eventId",
   authenticateUser,
+  authorizeSelfOrAdmin,
   ParticipationController.participate,
 );
 /**

--- a/src/routes/types.route.ts
+++ b/src/routes/types.route.ts
@@ -1,5 +1,9 @@
 import { Router } from "express";
 import { TypeController } from "../controllers/types.controller";
+import {
+  authenticateUser,
+  authorizeAdmin,
+} from "../middlewares/authentication.middleware";
 const router = Router();
 
 /**
@@ -83,6 +87,8 @@ router.get("/types/:id", TypeController.getTypeById);
  *     tags:
  *       - Types
  *     summary: Create a new type
+ *     security:
+ *      - BearerAuth: []
  *     requestBody:
  *       required: true
  *       content:
@@ -100,8 +106,15 @@ router.get("/types/:id", TypeController.getTypeById);
  *         description: Missing required field
  *       409:
  *         description: Type already exists
+ *       403:
+ *         description: Forbidden
  */
-router.post("/types", TypeController.createType);
+router.post(
+  "/types",
+  authenticateUser,
+  authorizeAdmin,
+  TypeController.createType,
+);
 
 /**
  * @swagger
@@ -110,6 +123,8 @@ router.post("/types", TypeController.createType);
  *     tags:
  *       - Types
  *     summary: Update an existing type
+ *     security:
+ *       - BearerAuth: []
  *     parameters:
  *       - in: path
  *         name: id
@@ -137,7 +152,12 @@ router.post("/types", TypeController.createType);
  *       409:
  *         description: Type already exists
  */
-router.put("/types/:id", TypeController.updateType);
+router.put(
+  "/types/:id",
+  authenticateUser,
+  authorizeAdmin,
+  TypeController.updateType,
+);
 
 /**
  * @swagger
@@ -146,6 +166,8 @@ router.put("/types/:id", TypeController.updateType);
  *     tags:
  *       - Types
  *     summary: Delete a type
+ *     security:
+ *       - BearerAuth: []
  *     parameters:
  *       - in: path
  *         name: id
@@ -163,6 +185,11 @@ router.put("/types/:id", TypeController.updateType);
  *       409:
  *         description: Type already exists
  */
-router.delete("/types/:id", TypeController.deleteType);
+router.delete(
+  "/types/:id",
+  authenticateUser,
+  authorizeAdmin,
+  TypeController.deleteType,
+);
 
 export default router;


### PR DESCRIPTION
---
name: 'Pull Request for manage admin access'
title: "[Feature] Manage admin access"
labels: 'feature'
assignees: @julgndr16 
---

## 📌 **Description**
This pull request implements role-based access control for several API endpoints to ensure restricted actions for administrators.
The changes enforce different access levels for regular users, administrators, and event owners.

## 🛠 **Changes Made**
- [x] **Implemented access control for `/api/events`**:
- Admins can view all events (moderated & unmoderated)
- Regular users can only view moderated events
- ` GET /api/events/{id}`: if the event is not moderated, only the person responsible for the event or an admin can retrieve it
- [x] **Secured event participation (`POST /api/participations/users/{id}/events/{id}`)**
- Users can only register themselves for an event
- Admins can register any user for an event
- [x] **Applied admin-only restrictions to event types (`/api/types`)**
- GET /api/types and GET /api/types/{id} → Public access.
- POST /api/types → Admin-only.
- PUT /api/types/{id} → Admin-only.
- DELETE /api/types/{id} → Admin-only.
- [x] Middleware optionalAuth added to allow optional authentication on `GET /api/events` & `GET /api/events/:id`
- [x] Middleware authorizeAdmin, authorizeSelfOrAdmin added for access control

## 📂 **Related Issues**
Link any related issues that this merge request addresses:
- Closes #35 

## 📌 **Additional Notes**
- Tested all role-restricted endpoints via Swagger UI to verify correct access control
- Security improvements by preventing unauthorized access to unmoderated events
